### PR TITLE
feat: 버튼 컴포넌트 패키지 추가 및 응용

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "graph": "nx run-many --target=build --graph",
     "dev:all": "yarn dev:storybook && yarn dev:packages",
     "dev:storybook": "nx storybook @ooz/storybook",
-    "dev:packages": "nx run-many --target=dev --projects='@ooz/react-components-*'"
+    "dev:packages": "nx run-many --target=dev --projects='@ooz/react-components-*,@ooz/react-hooks-*'"
   },
   "packageManager": "yarn@4.4.0",
   "devDependencies": {

--- a/packages/react/components/button/build.js
+++ b/packages/react/components/button/build.js
@@ -1,0 +1,12 @@
+import run from "@ooz/esbuild-config";
+import pkg from "./package.json" assert { type: "json" };
+import { vanillaExtractPlugin } from "@vanilla-extract/esbuild-plugin";
+
+const config = {
+  plugins: [vanillaExtractPlugin()],
+};
+
+run({
+  pkg,
+  config,
+});

--- a/packages/react/components/button/package.json
+++ b/packages/react/components/button/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@ooz/react-components-button",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./style.css": "./dist/index.css"
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:js && yarn build:type && yarn build:css",
+    "build:js": "node build.js",
+    "build:type": "yarn tsc --emitDeclarationOnly",
+    "clean": "rm -rf dist",
+    "dev": "yarn build:js --watch && yarn build:type --watch"
+  },
+  "devDependencies": {
+    "@ooz/esbuild-config": "workspace:^",
+    "@ooz/themes": "workspace:^",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vanilla-extract/css": "^1.13.0",
+    "@vanilla-extract/dynamic": "^2.1.1",
+    "@vanilla-extract/esbuild-plugin": "^2.3.0",
+    "@vanilla-extract/recipes": "^0.5.0",
+    "@vanilla-extract/sprinkles": "^1.6.1",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.29",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.5.4"
+  },
+  "peerDependencies": {
+    "@ooz/themes": "workspace:^",
+    "react": "*"
+  },
+  "dependencies": {
+    "clsx": "^2.0.0"
+  }
+}

--- a/packages/react/components/button/package.json
+++ b/packages/react/components/button/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@ooz/esbuild-config": "workspace:^",
+    "@ooz/react-hooks-button": "workspace:^",
     "@ooz/themes": "workspace:^",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/packages/react/components/button/src/Button.tsx
+++ b/packages/react/components/button/src/Button.tsx
@@ -21,9 +21,7 @@ const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
     leftIcon,
     rightIcon,
     isLoading,
-    isDisabled = false,
     children,
-    onKeyDown,
     style,
   } = props;
 
@@ -37,26 +35,9 @@ const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
       ? vars.colors.$scale[color][700]
       : vars.colors.$scale[color][100];
 
-  const disabled = isDisabled || isLoading;
-
-  // button a11y
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    onKeyDown?.(event);
-
-    if (event.key === "Enter" || event.key === "13") {
-      event.preventDefault();
-      event.currentTarget.click();
-    }
-  };
-
   return (
     <button
       {...props}
-      ref={ref}
-      onKeyDown={handleKeyDown}
-      onClick={() => {
-        console.log("test");
-      }}
       role="button"
       className={clsx([
         buttonStyle({
@@ -64,8 +45,8 @@ const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
           variant,
         }),
       ])}
-      data-loading={isLoading}
-      disabled={disabled}
+      // 기능 ^
+      ref={ref}
       style={{
         ...assignInlineVars({
           [enableColorVariant]: enableColor,

--- a/packages/react/components/button/src/Button.tsx
+++ b/packages/react/components/button/src/Button.tsx
@@ -11,8 +11,10 @@ import {
   spinnerStyle,
 } from "./style.css";
 import { vars } from "@ooz/themes";
+import { useButton } from "@ooz/react-hooks-button";
 
 const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
+  const { buttonProps } = useButton(props);
   const {
     variant = "solid",
     size = "md",
@@ -37,8 +39,7 @@ const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
 
   return (
     <button
-      {...props}
-      role="button"
+      {...buttonProps}
       className={clsx([
         buttonStyle({
           size,

--- a/packages/react/components/button/src/Button.tsx
+++ b/packages/react/components/button/src/Button.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { ButtonProps } from "./types";
+import { clsx } from "clsx";
+import { assignInlineVars } from "@vanilla-extract/dynamic";
+import {
+  activeColorVariant,
+  buttonStyle,
+  enableColorVariant,
+  hoverColorVariant,
+  spanStyle,
+  spinnerStyle,
+} from "./style.css";
+import { vars } from "@ooz/themes";
+
+const Button = (props: ButtonProps, ref: React.Ref<HTMLButtonElement>) => {
+  const {
+    variant = "solid",
+    size = "md",
+    color = "gray",
+
+    leftIcon,
+    rightIcon,
+    isLoading,
+    isDisabled = false,
+    children,
+    onKeyDown,
+    style,
+  } = props;
+
+  const enableColor = vars.colors.$scale[color][500];
+  const hoverColor =
+    variant === "solid"
+      ? vars.colors.$scale[color][600]
+      : vars.colors.$scale[color][50];
+  const activeColor =
+    variant === "solid"
+      ? vars.colors.$scale[color][700]
+      : vars.colors.$scale[color][100];
+
+  const disabled = isDisabled || isLoading;
+
+  // button a11y
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    onKeyDown?.(event);
+
+    if (event.key === "Enter" || event.key === "13") {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  };
+
+  return (
+    <button
+      {...props}
+      ref={ref}
+      onKeyDown={handleKeyDown}
+      onClick={() => {
+        console.log("test");
+      }}
+      role="button"
+      className={clsx([
+        buttonStyle({
+          size,
+          variant,
+        }),
+      ])}
+      data-loading={isLoading}
+      disabled={disabled}
+      style={{
+        ...assignInlineVars({
+          [enableColorVariant]: enableColor,
+          [hoverColorVariant]: hoverColor,
+          [activeColorVariant]: activeColor,
+        }),
+        ...style,
+      }}
+    >
+      {isLoading && <div className={spinnerStyle({ size })} />}
+      {leftIcon && <span className={spanStyle({ size })}>{leftIcon}</span>}
+      <span>{children}</span>
+      {rightIcon && <span className={spanStyle({ size })}>{rightIcon}</span>}
+    </button>
+  );
+};
+
+const _Button = React.forwardRef(Button);
+export { _Button as Button };

--- a/packages/react/components/button/src/index.ts
+++ b/packages/react/components/button/src/index.ts
@@ -1,0 +1,2 @@
+export { Button } from "./Button";
+export type { ButtonProps } from "./types";

--- a/packages/react/components/button/src/style.css.ts
+++ b/packages/react/components/button/src/style.css.ts
@@ -1,0 +1,174 @@
+import { recipe } from "@vanilla-extract/recipes";
+import { createVar, keyframes } from "@vanilla-extract/css";
+import { classes, vars } from "@ooz/themes";
+
+// https://vanilla-extract.style/documentation/packages/dynamic/
+export const enableColorVariant = createVar(); // 500
+export const hoverColorVariant = createVar(); // 600 outline 50 ghost 50
+export const activeColorVariant = createVar(); // 700 outline 100 ghost 100
+
+export const buttonStyle = recipe({
+  base: {
+    // reset
+    margin: 0,
+    padding: 0,
+    border: 0,
+
+    borderRadius: vars.box.radii.md,
+    display: "flex",
+    alignItems: "center",
+    cursor: "pointer",
+    userSelect: "none",
+    transition: "background-color 0.2s, color 0.2s, border-color 0.2s",
+    // @ts-ignore
+    "&[disabled]": {
+      opacity: 0.4,
+      cursor: "not-allowed",
+    },
+    '&[data-loading="true"]': {
+      "& span": {
+        opacity: 0,
+      },
+    },
+    "&:focus-visible": {
+      outline: "none",
+
+      boxShadow: vars.box.shadows.outline,
+    },
+  },
+  variants: {
+    size: {
+      xs: {
+        ...classes.typography.text.xs,
+        fontWeight: vars.typography.fontWeight[600],
+        padding: "0 0.5rem",
+        gap: "0.5rem",
+        height: "1.5rem",
+      },
+      sm: {
+        ...classes.typography.text.sm,
+        fontWeight: vars.typography.fontWeight[600],
+        padding: "0 0.75rem",
+        gap: "0.5rem ",
+        height: "2rem",
+      },
+      md: {
+        ...classes.typography.text.md,
+        fontWeight: vars.typography.fontWeight[600],
+        padding: "0 1rem",
+        gap: "0.5rem",
+        height: "2.5rem",
+      },
+      lg: {
+        ...classes.typography.text.lg,
+        fontWeight: vars.typography.fontWeight[600],
+        padding: "0 1.5rem",
+        gap: "0.5rem",
+        height: "3rem",
+      },
+    },
+    variant: {
+      solid: {
+        backgroundColor: enableColorVariant,
+        color: vars.colors.$scale.gray[50],
+
+        "&:hover:not([disabled])": {
+          backgroundColor: hoverColorVariant,
+        },
+        "&:active:not([disabled])": {
+          backgroundColor: activeColorVariant,
+        },
+      },
+      outline: {
+        border: `1px solid ${enableColorVariant}`,
+        color: enableColorVariant,
+
+        "&:hover:not([disabled])": {
+          backgroundColor: hoverColorVariant,
+        },
+        "&:active:not([disabled])": {
+          backgroundColor: activeColorVariant,
+        },
+      },
+      ghost: {
+        color: enableColorVariant,
+
+        "&:hover:not([disabled])": {
+          backgroundColor: hoverColorVariant,
+        },
+        "&:active:not([disabled])": {
+          backgroundColor: activeColorVariant,
+        },
+      },
+    },
+  },
+});
+
+export const spanStyle = recipe({
+  base: {
+    display: "flex",
+    alignItems: "center",
+  },
+  variants: {
+    size: {
+      xs: {
+        ...classes.typography.text.xs,
+        fontWeight: vars.typography.fontWeight[600],
+      },
+      sm: {
+        ...classes.typography.text.sm,
+        fontWeight: vars.typography.fontWeight[600],
+      },
+      md: {
+        ...classes.typography.text.md,
+        fontWeight: vars.typography.fontWeight[600],
+      },
+      lg: {
+        ...classes.typography.text.lg,
+        fontWeight: vars.typography.fontWeight[600],
+      },
+    },
+  },
+});
+
+const spinKeyframes = keyframes({
+  "0%": { transform: "rotate(0deg)" },
+  "100%": { transform: "rotate(360deg)" },
+});
+
+export const spinnerStyle = recipe({
+  base: {
+    position: "absolute",
+    animation: `${spinKeyframes} 0.45s linear infinite`,
+    display: "inline-block",
+    borderTop: "2px solid currentcolor",
+    borderRight: "2px solid currentcolor",
+    borderBottom: "2px solid transparent",
+    borderLeft: "2px solid transparent",
+    borderRadius: "50%",
+  },
+  variants: {
+    size: {
+      xs: {
+        width: vars.typography.fontSize[12],
+        height: vars.typography.fontSize[12],
+        left: `calc(50% - ${vars.typography.fontSize[12]}/2)`,
+      },
+      sm: {
+        width: vars.typography.fontSize[14],
+        height: vars.typography.fontSize[14],
+        left: `calc(50% - ${vars.typography.fontSize[14]}/2)`,
+      },
+      md: {
+        width: vars.typography.fontSize[16],
+        height: vars.typography.fontSize[16],
+        left: `calc(50% - ${vars.typography.fontSize[16]}/2)`,
+      },
+      lg: {
+        width: vars.typography.fontSize[18],
+        height: vars.typography.fontSize[18],
+        left: `calc(50% - ${vars.typography.fontSize[18]}/2)`,
+      },
+    },
+  },
+});

--- a/packages/react/components/button/src/types.ts
+++ b/packages/react/components/button/src/types.ts
@@ -1,0 +1,11 @@
+import { vars } from "@ooz/themes";
+
+export type ButtonProps = {
+  color?: keyof typeof vars.colors.$scale;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  size?: "xs" | "sm" | "md" | "lg";
+  variant?: "solid" | "outline" | "ghost";
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;

--- a/packages/react/components/button/tsconfig.json
+++ b/packages/react/components/button/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  }
+}

--- a/packages/react/components/layout/src/core/style.css.ts
+++ b/packages/react/components/layout/src/core/style.css.ts
@@ -1,5 +1,15 @@
 import { vars } from "@ooz/themes";
+import { style } from "@vanilla-extract/css";
 import { defineProperties, createSprinkles } from "@vanilla-extract/sprinkles";
+
+export const BaseStyle = style({
+  // @ts-ignore
+  "&:focus-visible": {
+    outline: "none",
+
+    boxShadow: vars.box.shadows.outline,
+  },
+});
 
 // https://vanilla-extract.style/documentation/packages/sprinkles
 const MarginAndPaddingProperties = defineProperties({

--- a/packages/react/components/layout/src/layout/Box.tsx
+++ b/packages/react/components/layout/src/layout/Box.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { BoxProps } from "./types";
 import { clsx } from "clsx";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { extractSprinkleProps } from "../utils/properties";
 import { vars } from "@ooz/themes";
 
@@ -14,6 +14,7 @@ const Box = (props: BoxProps, ref: React.Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/components/layout/src/layout/Flex.tsx
+++ b/packages/react/components/layout/src/layout/Flex.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FlexProps } from "./types";
 import { clsx } from "clsx";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { extractSprinkleProps } from "../utils/properties";
 import { vars } from "@ooz/themes";
 
@@ -27,6 +27,7 @@ const Flex = (props: FlexProps, ref: React.Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/components/layout/src/layout/Grid.tsx
+++ b/packages/react/components/layout/src/layout/Grid.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { GridProps } from "./types";
 import { clsx } from "clsx";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { extractSprinkleProps } from "../utils/properties";
 import { vars } from "@ooz/themes";
 
@@ -30,6 +30,7 @@ const Grid = (props: GridProps, ref: React.Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/components/layout/src/layout/GridItem.tsx
+++ b/packages/react/components/layout/src/layout/GridItem.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { GridItemProps } from "./types";
 import { clsx } from "clsx";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { extractSprinkleProps } from "../utils/properties";
 import { vars } from "@ooz/themes";
 
@@ -26,6 +26,7 @@ const GridItem = (props: GridItemProps, ref: React.Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/components/layout/src/typography/Heading.tsx
+++ b/packages/react/components/layout/src/typography/Heading.tsx
@@ -4,7 +4,7 @@ import { forwardRef, Ref } from "react";
 import { textStyle } from "./style.css";
 import { HeadingProps } from "./types";
 import { clsx } from "clsx";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { extractSprinkleProps } from "../utils/properties";
 
 const Heading = (props: HeadingProps, ref: Ref<HTMLElement>) => {
@@ -16,6 +16,7 @@ const Heading = (props: HeadingProps, ref: Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/components/layout/src/typography/Text.tsx
+++ b/packages/react/components/layout/src/typography/Text.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { TextProps } from "./types";
-import { StyleSprinkles } from "../core/style.css";
+import { BaseStyle, StyleSprinkles } from "../core/style.css";
 import { vars } from "@ooz/themes";
 import { clsx } from "clsx";
 import { extractSprinkleProps } from "../utils/properties";
@@ -15,6 +15,7 @@ const Text = (props: TextProps, ref: React.Ref<HTMLElement>) => {
       ...props,
       ref,
       className: clsx([
+        BaseStyle,
         StyleSprinkles(
           extractSprinkleProps(props, Array.from(StyleSprinkles.properties)),
         ),

--- a/packages/react/hooks/button/build.js
+++ b/packages/react/hooks/button/build.js
@@ -1,0 +1,6 @@
+import run from "@ooz/esbuild-config";
+import pkg from "./package.json" assert { type: "json" };
+
+run({
+  pkg,
+});

--- a/packages/react/hooks/button/package.json
+++ b/packages/react/hooks/button/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ooz/react-hooks-button",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "yarn clean && yarn build:js && yarn build:type && yarn build:css",
+    "build:js": "node build.js",
+    "build:type": "yarn tsc --emitDeclarationOnly",
+    "clean": "rm -rf dist",
+    "dev": "yarn build:js --watch && yarn build:type --watch"
+  },
+  "devDependencies": {
+    "@ooz/esbuild-config": "workspace:^",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.5.4"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "dependencies": {
+    "clsx": "^2.0.0"
+  }
+}

--- a/packages/react/hooks/button/src/index.ts
+++ b/packages/react/hooks/button/src/index.ts
@@ -1,0 +1,2 @@
+export type { ButtonElementType, BaseButtonProps } from "./types";
+export { useButton } from "./useButton";

--- a/packages/react/hooks/button/src/index.ts
+++ b/packages/react/hooks/button/src/index.ts
@@ -1,2 +1,3 @@
 export type { ButtonElementType, BaseButtonProps } from "./types";
 export { useButton } from "./useButton";
+export { useToggleButton } from "./useToggleButton";

--- a/packages/react/hooks/button/src/types.ts
+++ b/packages/react/hooks/button/src/types.ts
@@ -1,0 +1,30 @@
+import { ComponentProps, HTMLAttributes } from "react";
+
+export type ButtonElementType = "button" | "a" | "div" | "span" | "input";
+
+export type BaseButtonProps<T extends ButtonElementType = "button"> = {
+  elementType?: T;
+  role?: string;
+  type?: "button" | "submit" | "reset";
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  tabIndex?: number;
+} & ComponentProps<T>;
+
+export type UseButtonReturn<T> = {
+  buttonProps: HTMLAttributes<T> & {
+    role?: string;
+    type?: "button" | "submit" | "reset";
+    tabIndex?: number;
+    disabled?: boolean;
+    "data-loading": boolean;
+  };
+};
+
+export type OverloadedButtonFunction = {
+  (props: BaseButtonProps<"button">): UseButtonReturn<HTMLButtonElement>;
+  (props: BaseButtonProps<"a">): UseButtonReturn<HTMLAnchorElement>;
+  (props: BaseButtonProps<"div">): UseButtonReturn<HTMLDivElement>;
+  (props: BaseButtonProps<"input">): UseButtonReturn<HTMLInputElement>;
+  (props: BaseButtonProps<"span">): UseButtonReturn<HTMLSpanElement>;
+};

--- a/packages/react/hooks/button/src/types.ts
+++ b/packages/react/hooks/button/src/types.ts
@@ -21,10 +21,37 @@ export type UseButtonReturn<T> = {
   };
 };
 
+export type UseToggleButtonReturn<T> = UseButtonReturn<T> & {
+  isSelected: boolean;
+};
+
 export type OverloadedButtonFunction = {
   (props: BaseButtonProps<"button">): UseButtonReturn<HTMLButtonElement>;
   (props: BaseButtonProps<"a">): UseButtonReturn<HTMLAnchorElement>;
   (props: BaseButtonProps<"div">): UseButtonReturn<HTMLDivElement>;
   (props: BaseButtonProps<"input">): UseButtonReturn<HTMLInputElement>;
   (props: BaseButtonProps<"span">): UseButtonReturn<HTMLSpanElement>;
+};
+
+export type OverloadedToggleButtonFunction = {
+  (
+    props: BaseButtonProps<"button">,
+    isSelected?: boolean,
+  ): UseToggleButtonReturn<HTMLButtonElement>;
+  (
+    props: BaseButtonProps<"a">,
+    isSelected?: boolean,
+  ): UseToggleButtonReturn<HTMLAnchorElement>;
+  (
+    props: BaseButtonProps<"div">,
+    isSelected?: boolean,
+  ): UseToggleButtonReturn<HTMLDivElement>;
+  (
+    props: BaseButtonProps<"input">,
+    isSelected?: boolean,
+  ): UseToggleButtonReturn<HTMLInputElement>;
+  (
+    props: BaseButtonProps<"span">,
+    isSelected?: boolean,
+  ): UseToggleButtonReturn<HTMLSpanElement>;
 };

--- a/packages/react/hooks/button/src/useButton.tsx
+++ b/packages/react/hooks/button/src/useButton.tsx
@@ -1,0 +1,99 @@
+import { BaseButtonProps, OverloadedButtonFunction } from "./types";
+
+// 사용하는 곳에서 제네릭 타입 지정
+export const useButton: OverloadedButtonFunction = (props: any): any => {
+  const {
+    elementType = "button",
+    isDisabled,
+    isLoading,
+    tabIndex,
+    onKeyDown,
+    type = "button",
+  } = props;
+
+  const disabled = isDisabled || isLoading;
+
+  // button a11y
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    onKeyDown?.(event);
+
+    if (event.key === " " || event.key === "Spacebar" || event.key === "32") {
+      if (disabled) return;
+      if (event.defaultPrevented) return;
+      if (elementType === "button") return;
+
+      event.preventDefault();
+      (event.currentTarget as HTMLElement).click();
+
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === "13") {
+      if (disabled) return;
+      if (event.defaultPrevented) return;
+      if (elementType === "input" && type !== "button") return;
+
+      event.preventDefault();
+      (event.currentTarget as HTMLElement).click();
+
+      return;
+    }
+  };
+
+  const baseProps = {
+    ...props,
+    "data-loading": isLoading,
+    tabIndex: disabled ? undefined : (tabIndex ?? 0),
+    onKeyDown: handleKeyDown,
+  };
+
+  let additionalProps = {};
+
+  switch (elementType) {
+    case "button": {
+      additionalProps = {
+        type: type ?? "button",
+        disabled,
+      };
+      break;
+    }
+    case "a": {
+      const { href, target, rel } = props as BaseButtonProps<"a">;
+
+      additionalProps = {
+        role: "button",
+        href: disabled ? undefined : href,
+        target: disabled ? undefined : target,
+        rel: disabled ? undefined : rel,
+        "area-disabled": isDisabled,
+      };
+      break;
+    }
+    case "input": {
+      additionalProps = {
+        role: "button",
+        type: props.type,
+        disabled,
+        "area-disabled": undefined,
+      };
+      break;
+    }
+    default: {
+      additionalProps = {
+        role: "button",
+        type: type ?? "button",
+        "area-disabled": isDisabled,
+      };
+      break;
+    }
+  }
+
+  const buttonProps = {
+    ...baseProps,
+    ...additionalProps,
+  };
+
+  return {
+    buttonProps,
+  };
+};

--- a/packages/react/hooks/button/src/useToggleButton.tsx
+++ b/packages/react/hooks/button/src/useToggleButton.tsx
@@ -1,0 +1,27 @@
+import { useToggle } from "@ooz/react-hooks-toggle";
+import { OverloadedToggleButtonFunction } from "./types";
+import { useButton } from "./useButton";
+
+export const useToggleButton: OverloadedToggleButtonFunction = (
+  props: any,
+  isSelected?: boolean,
+): any => {
+  const { isSelected: _isSelected, toggle } = useToggle({
+    isSelected,
+  });
+
+  const handleClick = (event: React.MouseEvent) => {
+    toggle();
+    props?.onClick?.(event);
+  };
+
+  const { buttonProps } = useButton({
+    ...props,
+    onClick: handleClick,
+  });
+
+  return {
+    buttonProps,
+    isSelected: _isSelected,
+  };
+};

--- a/packages/react/hooks/button/tsconfig.json
+++ b/packages/react/hooks/button/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  }
+}

--- a/packages/react/hooks/toggle/build.js
+++ b/packages/react/hooks/toggle/build.js
@@ -1,0 +1,6 @@
+import run from "@ooz/esbuild-config";
+import pkg from "./package.json" assert { type: "json" };
+
+run({
+  pkg,
+});

--- a/packages/react/hooks/toggle/package.json
+++ b/packages/react/hooks/toggle/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ooz/react-hooks-button",
+  "name": "@ooz/react-hooks-toggle",
   "version": "0.0.1",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@ooz/esbuild-config": "workspace:^",
-    "@ooz/react-hooks-toggle": "workspace:^",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "react": "^18.2.0",

--- a/packages/react/hooks/toggle/src/index.ts
+++ b/packages/react/hooks/toggle/src/index.ts
@@ -1,0 +1,2 @@
+export type { ToggleProps, UseToggleReturn } from "./types";
+export { useToggle } from "./useToggle";

--- a/packages/react/hooks/toggle/src/types.ts
+++ b/packages/react/hooks/toggle/src/types.ts
@@ -1,0 +1,9 @@
+export type ToggleProps = {
+  isSelected?: boolean;
+};
+
+export interface UseToggleReturn {
+  readonly isSelected: boolean;
+  setSelected(isSelected: boolean): void;
+  toggle(): void;
+}

--- a/packages/react/hooks/toggle/src/useToggle.tsx
+++ b/packages/react/hooks/toggle/src/useToggle.tsx
@@ -1,0 +1,18 @@
+import { useCallback, useState } from "react";
+import { ToggleProps, UseToggleReturn } from "./types";
+
+export const useToggle = ({
+  isSelected = false,
+}: ToggleProps): UseToggleReturn => {
+  const [toggle, setToggle] = useState<boolean>(isSelected);
+
+  const handleToggle = useCallback(() => {
+    setToggle((prevState) => !prevState);
+  }, []);
+
+  return {
+    isSelected: toggle,
+    setSelected: setToggle,
+    toggle: handleToggle,
+  };
+};

--- a/packages/react/hooks/toggle/tsconfig.json
+++ b/packages/react/hooks/toggle/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  }
+}

--- a/packages/themes/src/variables/box.ts
+++ b/packages/themes/src/variables/box.ts
@@ -54,4 +54,5 @@ export const shadows = {
   inner: "0px 2px 4px 0px rgba(0, 0, 0, 0.06) inset",
   darkLg:
     "0px 15px 40px 0px rgba(0, 0, 0, 0.40), 0px 5px 10px 0px rgba(0, 0, 0, 0.20), 0px 0px 0px 1px rgba(0, 0, 0, 0.10)",
+  outline: "0 0 0 3px rgba(66, 153, 225, 0.6)",
 };

--- a/services/storybook/package.json
+++ b/services/storybook/package.json
@@ -3,6 +3,7 @@
   "packageManager": "yarn@4.4.0",
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",
+    "@ooz/react-components-button": "workspace:^",
     "@ooz/react-components-layout": "workspace:^",
     "@ooz/themes": "workspace:^",
     "@storybook/addon-essentials": "^8.2.7",

--- a/services/storybook/package.json
+++ b/services/storybook/package.json
@@ -5,6 +5,7 @@
     "@chromatic-com/storybook": "^1.6.1",
     "@ooz/react-components-button": "workspace:^",
     "@ooz/react-components-layout": "workspace:^",
+    "@ooz/react-hooks-button": "workspace:^",
     "@ooz/themes": "workspace:^",
     "@storybook/addon-essentials": "^8.2.7",
     "@storybook/addon-interactions": "^8.2.7",

--- a/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
+++ b/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
@@ -1,6 +1,9 @@
+import * as React from "react";
 import "@ooz/react-components-button/style.css";
 import { Button as _Button } from "@ooz/react-components-button";
 import { vars } from "@ooz/themes";
+import { Text } from "@ooz/react-components-layout";
+import { useButton } from "@ooz/react-hooks-button";
 
 export default {
   title: "React Components/Button",
@@ -34,4 +37,29 @@ export const ButtonStory = {
     isLoading: false,
     leftIcon: "😀",
   },
+};
+
+const TextButton = () => {
+  const { buttonProps } = useButton({
+    elementType: "div",
+  });
+
+  return (
+    <Text
+      {...buttonProps}
+      as="div"
+      fontSize="md"
+      color="pink"
+      style={{
+        userSelect: "none",
+        cursor: "pointer",
+      }}
+    >
+      텍스트 버튼입니다.
+    </Text>
+  );
+};
+
+export const TextButtonStory = {
+  render: () => <TextButton />,
 };

--- a/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
+++ b/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
@@ -3,7 +3,7 @@ import "@ooz/react-components-button/style.css";
 import { Button as _Button } from "@ooz/react-components-button";
 import { vars } from "@ooz/themes";
 import { Text } from "@ooz/react-components-layout";
-import { useButton } from "@ooz/react-hooks-button";
+import { useButton, useToggleButton } from "@ooz/react-hooks-button";
 
 export default {
   title: "React Components/Button",
@@ -62,4 +62,25 @@ const TextButton = () => {
 
 export const TextButtonStory = {
   render: () => <TextButton />,
+};
+
+const ToggleButton = () => {
+  const { buttonProps, isSelected } = useToggleButton(
+    { elementType: "button" },
+    false,
+  );
+
+  return (
+    <_Button
+      {...buttonProps}
+      variant={isSelected ? "solid" : "outline"}
+      color="green"
+    >
+      {isSelected ? "😀" : "😂"}
+    </_Button>
+  );
+};
+
+export const ToggleButtonStory = {
+  render: () => <ToggleButton />,
 };

--- a/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
+++ b/services/storybook/stories/ReactComponents/Layout/Button.stories.tsx
@@ -1,0 +1,37 @@
+import "@ooz/react-components-button/style.css";
+import { Button as _Button } from "@ooz/react-components-button";
+import { vars } from "@ooz/themes";
+
+export default {
+  title: "React Components/Button",
+  component: _Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      options: ["xs", "sm", "md", "lg"],
+      control: "select",
+    },
+    color: {
+      options: Object.keys(vars.colors.$scale),
+      control: "select",
+    },
+    variant: {
+      options: ["solid", "outline", "ghost"],
+      control: "select",
+    },
+  },
+};
+
+export const ButtonStory = {
+  args: {
+    size: "lg",
+    children: "Button",
+    variant: "outline",
+    isDisabled: false,
+    isLoading: false,
+    leftIcon: "😀",
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,6 +2167,23 @@ __metadata:
   resolution: "@ooz/react-hooks-button@workspace:packages/react/hooks/button"
   dependencies:
     "@ooz/esbuild-config": "workspace:^"
+    "@ooz/react-hooks-toggle": "workspace:^"
+    "@types/react": "npm:^18.2.21"
+    "@types/react-dom": "npm:^18.2.7"
+    clsx: "npm:^2.0.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.5.4"
+  peerDependencies:
+    react: "*"
+  languageName: unknown
+  linkType: soft
+
+"@ooz/react-hooks-toggle@workspace:^, @ooz/react-hooks-toggle@workspace:packages/react/hooks/toggle":
+  version: 0.0.0-use.local
+  resolution: "@ooz/react-hooks-toggle@workspace:packages/react/hooks/toggle"
+  dependencies:
+    "@ooz/esbuild-config": "workspace:^"
     "@types/react": "npm:^18.2.21"
     "@types/react-dom": "npm:^18.2.7"
     clsx: "npm:^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,31 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ooz/react-components-button@workspace:^, @ooz/react-components-button@workspace:packages/react/components/button":
+  version: 0.0.0-use.local
+  resolution: "@ooz/react-components-button@workspace:packages/react/components/button"
+  dependencies:
+    "@ooz/esbuild-config": "workspace:^"
+    "@ooz/themes": "workspace:^"
+    "@types/react": "npm:^18.2.21"
+    "@types/react-dom": "npm:^18.2.7"
+    "@vanilla-extract/css": "npm:^1.13.0"
+    "@vanilla-extract/dynamic": "npm:^2.1.1"
+    "@vanilla-extract/esbuild-plugin": "npm:^2.3.0"
+    "@vanilla-extract/recipes": "npm:^0.5.0"
+    "@vanilla-extract/sprinkles": "npm:^1.6.1"
+    autoprefixer: "npm:^10.4.15"
+    clsx: "npm:^2.0.0"
+    postcss: "npm:^8.4.29"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.5.4"
+  peerDependencies:
+    "@ooz/themes": "workspace:^"
+    react: "*"
+  languageName: unknown
+  linkType: soft
+
 "@ooz/react-components-layout@workspace:^, @ooz/react-components-layout@workspace:packages/react/components/layout":
   version: 0.0.0-use.local
   resolution: "@ooz/react-components-layout@workspace:packages/react/components/layout"
@@ -2141,6 +2166,7 @@ __metadata:
   resolution: "@ooz/storybook@workspace:services/storybook"
   dependencies:
     "@chromatic-com/storybook": "npm:^1.6.1"
+    "@ooz/react-components-button": "workspace:^"
     "@ooz/react-components-layout": "workspace:^"
     "@ooz/themes": "workspace:^"
     "@storybook/addon-essentials": "npm:^8.2.7"
@@ -3386,6 +3412,15 @@ __metadata:
     modern-ahocorasick: "npm:^1.0.0"
     picocolors: "npm:^1.0.0"
   checksum: 10c0/57c53e961bc0a273fa792c65c1b6cc6ce45d8f0d3c8b239df6ece4fbf2c58d09764ed70773bf25582e3cc6789ccce2b920c33d177ef276f63c6604c85dbc5c01
+  languageName: node
+  linkType: hard
+
+"@vanilla-extract/dynamic@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@vanilla-extract/dynamic@npm:2.1.1"
+  dependencies:
+    "@vanilla-extract/private": "npm:^1.0.5"
+  checksum: 10c0/0c353b6326e73054a5ca1cfbb02e865cd8853e88976d7f53794e91ccf3fdfcab18211ad93750927b05c8d57e3816c1e56b55a8e24ad7f616b5e627339a3d36b6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,6 +2117,7 @@ __metadata:
   resolution: "@ooz/react-components-button@workspace:packages/react/components/button"
   dependencies:
     "@ooz/esbuild-config": "workspace:^"
+    "@ooz/react-hooks-button": "workspace:^"
     "@ooz/themes": "workspace:^"
     "@types/react": "npm:^18.2.21"
     "@types/react-dom": "npm:^18.2.7"
@@ -2161,7 +2162,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ooz/react-hooks-button@workspace:packages/react/hooks/button":
+"@ooz/react-hooks-button@workspace:^, @ooz/react-hooks-button@workspace:packages/react/hooks/button":
   version: 0.0.0-use.local
   resolution: "@ooz/react-hooks-button@workspace:packages/react/hooks/button"
   dependencies:
@@ -2184,6 +2185,7 @@ __metadata:
     "@chromatic-com/storybook": "npm:^1.6.1"
     "@ooz/react-components-button": "workspace:^"
     "@ooz/react-components-layout": "workspace:^"
+    "@ooz/react-hooks-button": "workspace:^"
     "@ooz/themes": "workspace:^"
     "@storybook/addon-essentials": "npm:^8.2.7"
     "@storybook/addon-interactions": "npm:^8.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ooz/react-hooks-button@workspace:packages/react/hooks/button":
+  version: 0.0.0-use.local
+  resolution: "@ooz/react-hooks-button@workspace:packages/react/hooks/button"
+  dependencies:
+    "@ooz/esbuild-config": "workspace:^"
+    "@types/react": "npm:^18.2.21"
+    "@types/react-dom": "npm:^18.2.7"
+    clsx: "npm:^2.0.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.5.4"
+  peerDependencies:
+    react: "*"
+  languageName: unknown
+  linkType: soft
+
 "@ooz/storybook@workspace:services/storybook":
   version: 0.0.0-use.local
   resolution: "@ooz/storybook@workspace:services/storybook"


### PR DESCRIPTION
- `@ooz/react-components-button`:  버튼 컴포넌트 패키지 생성
- `@ooz/react-hooks-button`:  headless hooks 패턴 - 기능과  버튼 스타일 분리
- `@ooz/react-hooks-toggle`: 버튼 컴포넌트 응용 -  isSelected 불린 값을 받는 토글 버튼
-  기타: core style에 BaseStyle 추가 및 적용
